### PR TITLE
In zoomed-in mode, the gallery image follows the cursor

### DIFF
--- a/src/overview/ImageGallery.test.jsx
+++ b/src/overview/ImageGallery.test.jsx
@@ -112,8 +112,9 @@ describe('click to zoom', () => {
   it('shrinks the gallery', () => {
     render(<Overview product={product} rating={rating} styles={styles}/>);
     const gallery = screen.getByRole('figure');
-    fireEvent.click(gallery);
-    fireEvent.click(gallery);
+    fireEvent.click(gallery); // expanded
+    fireEvent.click(gallery); // zoomed
+    fireEvent.click(gallery); // normal
     expect(document.querySelector('.info')).toBeVisible();
   });
 

--- a/src/overview/index.jsx
+++ b/src/overview/index.jsx
@@ -11,20 +11,23 @@ import { product, rating, styles } from './sampleData';
 
 const Overview = (/* { product, rating, styles } */) => {
   const [styleIndex, setStyleIndex] = React.useState(0);
-  // whether or not the image gallery expands over the product info
-  const [expand, setExpand] = React.useState(false);
+  // zoomed in amount:
+  // 0: standard view
+  // 1: expanded view
+  // 2: zoomed-in view
+  const [zoom, setZoom] = React.useState(0);
   // reset state when a new product is displayed
   React.useEffect(() => {
     setStyleIndex(0);
-    setExpand(false);
+    setZoom(0);
   }, [product.id]);
   const style = styles[styleIndex];
 
   return (
     <div id="overview">
       <div>
-        <ImageGallery style={style} expand={expand} setExpand={setExpand}/>
-        <div className="info" style={{display: expand ? 'none' : null}}>
+        <ImageGallery style={style} zoom={zoom} setZoom={setZoom}/>
+        <div className="info" style={{display: zoom === 0 ? null : 'none'}}>
           <ProductInformation product={product} rating={rating} style={style}/>
           <StyleSelector
             styles={styles}

--- a/src/overview/overview.scss
+++ b/src/overview/overview.scss
@@ -25,6 +25,7 @@ $foreground: var(--foreground);
         background-size: cover;
         background-position: center;
         display: flex;
+        user-select: none;
 
         button {
             color: black;
@@ -147,14 +148,33 @@ $foreground: var(--foreground);
             border-color: white;
         }
     }
-    .expand img {
-        width: 10px;
-        height: 10px;
-        filter: brightness(0);
-        box-shadow: 0px 0px 2px black;
+
+    .zoom-0 {
+        cursor: zoom-in;
     }
-    .expand .selected {
-        filter: brightness(100);
+
+    .zoom-1 {
+        cursor: crosshair;
+
+        .thumbnails img {
+            width: 10px;
+            height: 10px;
+            filter: brightness(0);
+            box-shadow: 0px 0px 2px black;
+
+            &.selected {
+                filter: brightness(100);
+            }
+        }
+    }
+
+    .zoom-2 {
+        cursor: zoom-out;
+        background-size: 250%;
+
+        .thumbnails, button {
+            display: none;
+        }
     }
 }
 


### PR DESCRIPTION
![zoom](https://user-images.githubusercontent.com/1874214/140234072-de89a648-b17c-4e6c-ac40-4c7842a3aee7.gif)

### Created React components

- Thumbnails
Props:
  - `photos: Photo[]` - photos of a style
  - `page: number` - index in `photos` of currently-viewed image
  - `setPage: Dispatch` - setter for `page`
  - `thumbOffset: number` - how far through the thumbnails the user has scrolled
  - `setThumbOffset:  Dispatch` - setter for `thumbOffset`
 
### Modified React components
- ImageGallery
  - The `expand: boolean` property has been replaced by `zoom: number`
    - 0: normal view
    - 1: expanded view
    - 2: zoomed-in view
  - `setExpand` has likewise been replaced by `setZoom`

### Functionality

If the user clicks on the gallery image while in expanded view, the image scales 2.5x and the buttons and thumbnails disappear. In this mode, moving the mouse within the gallery causes the background image itself to move accordingly, so that the entire image may be seen.

Clicking on the image again returns the gallery to standard view.