### PR TITLE
Review list scroll

### DIFF
--- a/src/ratings-and-reviews/components/ReviewList.jsx
+++ b/src/ratings-and-reviews/components/ReviewList.jsx
@@ -1,11 +1,21 @@
-import React from 'react';
+import React, {useState} from 'react';
 import ReviewTile from './ReviewTile.jsx';
 
-const ReviewList = ({reviewList}) => (
 
-  <div className="review-list">
-    {reviewList.map((review) => <ReviewTile review={review} key={review.review_id}/>)}
-  </div>
-);
+
+const ReviewList = ({reviewList}) => {
+
+  let [count, setCount] = useState(2);
+
+  return (
+    <div className="review-list">
+      {reviewList.slice(0, count).map((review) => <ReviewTile review={review} key={review.review_id}/>)}
+      { count <= reviewList.length &&
+        <button id="more-reviews" onClick={() => setCount(count + 2) }>More Reviews</button>
+      }
+      <button className="add-a-review">Add A Review +</button>
+    </div>
+  );
+};
 
 export default ReviewList;

--- a/src/ratings-and-reviews/components/ReviewList.test.jsx
+++ b/src/ratings-and-reviews/components/ReviewList.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ReviewList from './ReviewList.jsx';
+import {reviewList} from '../sampleData.js';
+
+it('Only renders more reviews button if there are more reviews to render', () => {
+
+  const reviews = reviewList;
+
+
+  const app = render(<ReviewList reviewList={reviews}/>);
+
+  let button = document.querySelector('#more-reviews');
+
+  fireEvent.click(button);
+  expect(document.querySelector('#more-reviews')).toBeTruthy;
+
+  fireEvent.click(button);
+  expect(document.querySelector('#more-reviews')).toBeTruthy;
+
+  fireEvent.click(button);
+  expect(document.querySelector('#more-reviews')).toBe(null);
+});

--- a/src/ratings-and-reviews/ratings-and-reviews.scss
+++ b/src/ratings-and-reviews/ratings-and-reviews.scss
@@ -31,6 +31,11 @@
   font-weight: lighter;
 }
 
+.review-list {
+  overflow-y: scroll;
+  height: 750px;
+}
+
 progress {
   border-radius: 7px;
   height: 12px;
@@ -64,6 +69,7 @@ progress::-webkit-progress-value {
 
 .review-helpful {
   margin-left: 550px;
+  text-align: right;
 }
 
 .checkmark {


### PR DESCRIPTION
Review List renders two reviews by default. Clicking the more reviews button will load two more reviews until there are no more reviews to load, in which case the more reviews button will no longer be rendered.

When the Review List hits the container limit, the list will become scrollable.

http://g.recordit.co/CTmelgfuLS.gif

