### PR TITLE
Support photos in Answers

### DIFF
--- a/src/common/modal/index.jsx
+++ b/src/common/modal/index.jsx
@@ -5,10 +5,14 @@ import './modal.scss';
  * @param {Object} props
  * @param {React.ReactChildren} props.children
  * @param {React.MouseEventHandler} props.hide
+ * @param {boolean} full
  */
-const Modal = ({ children, hide }) => (
+const Modal = ({ children, hide, full }) => (
   <div className="modalBack" onClick={hide}>
-    <div className="modal" onClick={event => event.stopPropagation()}>
+    <div
+      className={'modal' + (full ? ' full' : '') }
+      onClick={event => event.stopPropagation()}
+    >
       {children}
     </div>
   </div>

--- a/src/common/modal/modal.scss
+++ b/src/common/modal/modal.scss
@@ -29,6 +29,11 @@
     font-weight: normal;
   }
 
+  > img:first-child:last-child {
+    min-height: 100%;
+    min-width: 100%;
+  }
+
   input {
     width: 100%;
   }
@@ -62,5 +67,15 @@
   textarea, input {
     font-size: 1em;
     font-weight: unset;
+  }
+
+  &.full {
+    padding: 0;
+
+    img {
+      min-width: 100%;
+      min-height: 100%;
+      object-fit: contain;
+    }
   }
 }

--- a/src/common/modal/modal.scss
+++ b/src/common/modal/modal.scss
@@ -29,6 +29,10 @@
     font-weight: normal;
   }
 
+  input {
+    width: 100%;
+  }
+
   span {
     float: right;
     text-align: right;

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,6 @@
 :root {
   --foreground: #525252;
+  --background: #ebebeb;
 }
 
 a, body, input, select, button {
@@ -9,6 +10,10 @@ a, body, input, select, button {
 
 body {
     margin: 0;
+}
+
+img {
+  background-color: var(--background);
 }
 
 #root {
@@ -44,7 +49,7 @@ button.interact {
     cursor: pointer;
 
     &:hover {
-      background: #eee;
+      background: var(--background);
     }
 }
 

--- a/src/questions-and-answers/AnswerModal.jsx
+++ b/src/questions-and-answers/AnswerModal.jsx
@@ -9,107 +9,104 @@ import api from '../api';
  * @param {Question} props.question
  * @param {React.MouseEventHandler} props.hide
  */
-const AnswerModal = ({ hide, product, question }) => {
-  const [photos, setPhotos] = React.useState([]);
-  return (
-    <Modal hide={hide}>
-      <h1>Submit your Answer</h1>
-      <h2>{product.name}: {question.question_body}</h2>
-      <Formik
-        initialValues={{body: '', name: '', email: '', photos: []}}
-        validate={values => {
-          const errors = {};
-          if (!values.body) {
-            errors.body = 'Required';
-          }
-          if (!values.name) {
-            errors.name = 'Required';
-          }
-          if (!values.email) {
-            errors.email = 'Required';
-          } else if (!validateEmail(values.email)) {
-            errors.email = 'Invalid email address';
-          }
-          return errors;
-        }}
-        onSubmit={(values, { resetForm, setSubmitting }) =>
-          api.createAnswer(question.question_id, values)
-            .then(() => {
-              setSubmitting(false);
-              resetForm();
-              hide();
-            })
-            .catch(console.error)
+const AnswerModal = ({ hide, product, question }) => (
+  <Modal hide={hide}>
+    <h1>Submit your Answer</h1>
+    <h2>{product.name}: {question.question_body}</h2>
+    <Formik
+      initialValues={{body: '', name: '', email: '', photos: []}}
+      validate={values => {
+        const errors = {};
+        if (!values.body) {
+          errors.body = 'Required';
         }
-      >
-        {({ isSubmitting, isValidating, errors, values }) => (
-          <Form>
-            <label htmlFor="body">
-              Your Answer*
-            </label>
-            <Field
-              className="interact"
-              type="text"
-              as="textarea"
-              name="body"
-              id="body"
-              maxLength="1000"
-              required
-            />
-            <ErrorMessage name="body" component="span"/>
-            <label htmlFor="name">What is your nickname*</label>
-            <Field
-              className="interact"
-              type="text"
-              name="name"
-              id="name"
-              placeholder="Example: jack543!"
-              maxLength="60"
-              required
-            />
+        if (!values.name) {
+          errors.name = 'Required';
+        }
+        if (!values.email) {
+          errors.email = 'Required';
+        } else if (!validateEmail(values.email)) {
+          errors.email = 'Invalid email address';
+        }
+        return errors;
+      }}
+      onSubmit={(values, { resetForm, setSubmitting }) =>
+        api.createAnswer(question.question_id, values)
+          .then(() => {
+            setSubmitting(false);
+            resetForm();
+            hide();
+          })
+          .catch(console.error)
+      }
+    >
+      {({ isSubmitting, isValidating, errors, values }) => (
+        <Form>
+          <label htmlFor="body">
+            Your Answer*
+          </label>
+          <Field
+            className="interact"
+            type="text"
+            as="textarea"
+            name="body"
+            id="body"
+            maxLength="1000"
+            required
+          />
+          <ErrorMessage name="body" component="span"/>
+          <label htmlFor="name">What is your nickname*</label>
+          <Field
+            className="interact"
+            type="text"
+            name="name"
+            id="name"
+            placeholder="Example: jack543!"
+            maxLength="60"
+            required
+          />
+          <div>
+            <ErrorMessage name="name" component="span"/>
+            For privacy reasons, do not use your full name or email address
+          </div>
+          <label htmlFor="email">Your email*</label>
+          <Field
+            className="interact"
+            type="email"
+            name="email"
+            id="email"
+            placeholder="Example: jack@email.com"
+            maxLength="60"
+            required
+          />
+          <div>
+            <ErrorMessage name="email" component="span"/>
+            For authentication reasons, you will not be emailed
+          </div>
+          <label htmlFor="photo">Attach Photos</label>
+          <FieldArray name="photos" render={arrayHelpers => (
             <div>
-              <ErrorMessage name="name" component="span"/>
-              For privacy reasons, do not use your full name or email address
+              {values.photos.length < 5 ? (
+                <input
+                  type="file"
+                  name="photo"
+                  id="photo"
+                  accept="image/*"
+                  onChange={event => arrayHelpers.push(URL.createObjectURL(event.currentTarget.files[0]))}
+                />
+              ) : null}
+              {values.photos.map(photo => (
+                <img src={photo}/>
+              ))}
             </div>
-            <label htmlFor="email">Your email*</label>
-            <Field
-              className="interact"
-              type="email"
-              name="email"
-              id="email"
-              placeholder="Example: jack@email.com"
-              maxLength="60"
-              required
-            />
-            <div>
-              <ErrorMessage name="email" component="span"/>
-              For authentication reasons, you will not be emailed
-            </div>
-            <label htmlFor="photo">Attach Photos</label>
-            <FieldArray name="photos" render={arrayHelpers => (
-              <div>
-                {values.photos.length < 5 ? (
-                  <input
-                    type="file"
-                    name="photo"
-                    id="photo"
-                    accept="image/*"
-                    onChange={event => arrayHelpers.push(URL.createObjectURL(event.currentTarget.files[0]))}
-                  />
-                ) : null}
-                {values.photos.map(photo => (
-                  <img src={photo}/>
-                ))}
-              </div>
-            )}/>
-            <button type="submit" className="interact" disabled={isSubmitting}>
-              Submit
-            </button>
-          </Form>
-        )}
-      </Formik>
-    </Modal>
-  );
-};
+          )}/>
+          <button type="submit" className="interact" disabled={isSubmitting}>
+            Submit
+          </button>
+        </Form>
+      )}
+    </Formik>
+  </Modal>
+);
 
 export default AnswerModal;

--- a/src/questions-and-answers/AnswerModal.jsx
+++ b/src/questions-and-answers/AnswerModal.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Formik, Form, Field, ErrorMessage } from 'formik';
+import { Formik, Form, Field, FieldArray, ErrorMessage } from 'formik';
 import { Modal, validateEmail } from '../common';
 import api from '../api';
 
@@ -9,90 +9,107 @@ import api from '../api';
  * @param {Question} props.question
  * @param {React.MouseEventHandler} props.hide
  */
-const AnswerModal = ({ hide, product, question }) => (
-  <Modal hide={hide}>
-    <h1>Submit your Answer</h1>
-    <h2>{product.name}: {question.question_body}</h2>
-    <Formik
-      initialValues={{body: '', name: '', email: ''}}
-      validate={values => {
-        const errors = {};
-        if (!values.body) {
-          errors.body = 'Required';
+const AnswerModal = ({ hide, product, question }) => {
+  const [photos, setPhotos] = React.useState([]);
+  return (
+    <Modal hide={hide}>
+      <h1>Submit your Answer</h1>
+      <h2>{product.name}: {question.question_body}</h2>
+      <Formik
+        initialValues={{body: '', name: '', email: '', photos: []}}
+        validate={values => {
+          const errors = {};
+          if (!values.body) {
+            errors.body = 'Required';
+          }
+          if (!values.name) {
+            errors.name = 'Required';
+          }
+          if (!values.email) {
+            errors.email = 'Required';
+          } else if (!validateEmail(values.email)) {
+            errors.email = 'Invalid email address';
+          }
+          return errors;
+        }}
+        onSubmit={(values, { resetForm, setSubmitting }) =>
+          api.createAnswer(question.question_id, values)
+            .then(() => {
+              setSubmitting(false);
+              resetForm();
+              hide();
+            })
+            .catch(console.error)
         }
-        if (!values.name) {
-          errors.name = 'Required';
-        }
-        if (!values.email) {
-          errors.email = 'Required';
-        } else if (!validateEmail(values.email)) {
-          errors.email = 'Invalid email address';
-        }
-        return errors;
-      }}
-      onSubmit={(values, { resetForm, setSubmitting }) =>
-        api.createAnswer(question.question_id, values)
-          .then(() => {
-            setSubmitting(false);
-            resetForm();
-            hide();
-          })
-          .catch(console.error)
-      }
-    >
-      {({ isSubmitting, isValidating, errors }) => (
-        <Form>
-          <label htmlFor="body">
-            Your Answer*
-            {Object.values(errors).length === 0 ? null : (
-              <span>You must enter the following:</span>
-            )}
-          </label>
-          <Field
-            className="interact"
-            type="text"
-            as="textarea"
-            name="body"
-            id="body"
-            maxLength="1000"
-            required
-          />
-          <ErrorMessage name="body" component="span"/>
-          <label htmlFor="name">What is your nickname*</label>
-          <Field
-            className="interact"
-            type="text"
-            name="name"
-            id="name"
-            placeholder="Example: jack543!"
-            maxLength="60"
-            required
-          />
-          <div>
-            <ErrorMessage name="name" component="span"/>
-            For privacy reasons, do not use your full name or email address
-          </div>
-          <label htmlFor="email">Your email*</label>
-          <Field
-            className="interact"
-            type="email"
-            name="email"
-            id="email"
-            placeholder="Example: jack@email.com"
-            maxLength="60"
-            required
-          />
-          <div>
-            <ErrorMessage name="email" component="span"/>
-            For authentication reasons, you will not be emailed
-          </div>
-          <button type="submit" className="interact" disabled={isSubmitting}>
-            Submit
-          </button>
-        </Form>
-      )}
-    </Formik>
-  </Modal>
-);
+      >
+        {({ isSubmitting, isValidating, errors, values }) => (
+          <Form>
+            <label htmlFor="body">
+              Your Answer*
+            </label>
+            <Field
+              className="interact"
+              type="text"
+              as="textarea"
+              name="body"
+              id="body"
+              maxLength="1000"
+              required
+            />
+            <ErrorMessage name="body" component="span"/>
+            <label htmlFor="name">What is your nickname*</label>
+            <Field
+              className="interact"
+              type="text"
+              name="name"
+              id="name"
+              placeholder="Example: jack543!"
+              maxLength="60"
+              required
+            />
+            <div>
+              <ErrorMessage name="name" component="span"/>
+              For privacy reasons, do not use your full name or email address
+            </div>
+            <label htmlFor="email">Your email*</label>
+            <Field
+              className="interact"
+              type="email"
+              name="email"
+              id="email"
+              placeholder="Example: jack@email.com"
+              maxLength="60"
+              required
+            />
+            <div>
+              <ErrorMessage name="email" component="span"/>
+              For authentication reasons, you will not be emailed
+            </div>
+            <label htmlFor="photo">Attach Photos</label>
+            <FieldArray name="photos" render={arrayHelpers => (
+              <div>
+                {values.photos.length < 5 ? (
+                  <input
+                    type="file"
+                    name="photo"
+                    id="photo"
+                    accept="image/*"
+                    onChange={event => arrayHelpers.push(URL.createObjectURL(event.currentTarget.files[0]))}
+                  />
+                ) : null}
+                {values.photos.map(photo => (
+                  <img src={photo}/>
+                ))}
+              </div>
+            )}/>
+            <button type="submit" className="interact" disabled={isSubmitting}>
+              Submit
+            </button>
+          </Form>
+        )}
+      </Formik>
+    </Modal>
+  );
+};
 
 export default AnswerModal;

--- a/src/questions-and-answers/AnswerTile.jsx
+++ b/src/questions-and-answers/AnswerTile.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import { Helpful, Report } from '../common';
+import { Helpful, Modal, Report } from '../common';
 
 const formatName = (name) => name === 'Seller' ? <em>{name}</em> : name;
 
@@ -8,25 +8,37 @@ const formatName = (name) => name === 'Seller' ? <em>{name}</em> : name;
  * @param {Object} props
  * @param {Answer} props.answer
  */
-const AnswerTile = ({ answer }) => (
-  <section>
-    <p>{answer.body}</p>
-    {answer.photos.length === 0 ? null : (
-      <p>
-        {answer.photos.map(photo => <img src={photo} key={photo}/>)}
-      </p>
-    )}
-    <footer className="details">
-      <span>
-        by {formatName(answer.answerer_name.trim())},
-        {moment(answer.date).format(' MMMM Do, YYYY')}
-      </span>
-      <Helpful type="answer" id={answer.id} score={answer.helpfulness}/>
-      <span>
-        <Report type="answer" id={answer.id}/>
-      </span>
-    </footer>
-  </section>
-);
+const AnswerTile = ({ answer }) => {
+  const [showModal, setShowModal] = React.useState(null);
+  const modal = showModal && (
+    <Modal full hide={() => setShowModal(false)}>
+      <img src={showModal}/>
+    </Modal>
+  );
+  const setModal = (event) => setShowModal(event.target.src);
+  return (
+    <section>
+      <p>{answer.body}</p>
+      {answer.photos.length === 0 ? null : (
+        <p>
+          {answer.photos.map(photo =>
+            <img src={photo} key={photo} onClick={setModal}/>
+          )}
+        </p>
+      )}
+      <footer className="details">
+        <span>
+          by {formatName(answer.answerer_name.trim())},
+          {moment(answer.date).format(' MMMM Do, YYYY')}
+        </span>
+        <Helpful type="answer" id={answer.id} score={answer.helpfulness}/>
+        <span>
+          <Report type="answer" id={answer.id}/>
+        </span>
+      </footer>
+      {modal}
+    </section>
+  );
+};
 
 export default AnswerTile;

--- a/src/questions-and-answers/AnswerTile.jsx
+++ b/src/questions-and-answers/AnswerTile.jsx
@@ -11,6 +11,11 @@ const formatName = (name) => name === 'Seller' ? <em>{name}</em> : name;
 const AnswerTile = ({ answer }) => (
   <section>
     <p>{answer.body}</p>
+    {answer.photos.length === 0 ? null : (
+      <p>
+        {answer.photos.map(photo => <img src={photo} key={photo}/>)}
+      </p>
+    )}
     <footer className="details">
       <span>
         by {formatName(answer.answerer_name.trim())},
@@ -20,7 +25,6 @@ const AnswerTile = ({ answer }) => (
       <span>
         <Report type="answer" id={answer.id}/>
       </span>
-
     </footer>
   </section>
 );

--- a/src/questions-and-answers/QuestionModal.jsx
+++ b/src/questions-and-answers/QuestionModal.jsx
@@ -43,9 +43,6 @@ const QuestionModal = ({ hide, product }) => (
         <Form>
           <label htmlFor="body">
             Your Question*
-            {Object.values(errors).length === 0 ? null : (
-              <span>You must enter the following:</span>
-            )}
           </label>
           <Field
             className="interact"

--- a/src/questions-and-answers/QuestionTile.jsx
+++ b/src/questions-and-answers/QuestionTile.jsx
@@ -59,6 +59,7 @@ const QuestionTile = ({ question, product }) => {
         {answers.map(([id, answer]) => <AnswerTile key={id} answer={answer}/>)}
         {accordionButton}
       </div>
+      {modal}
     </div>
   );
 };

--- a/src/questions-and-answers/questions-and-answers.scss
+++ b/src/questions-and-answers/questions-and-answers.scss
@@ -3,6 +3,18 @@
     margin: 0.65em 0;
   }
 
+  img {
+    max-height: 150px;
+    max-width: 18%;
+    border: 1px solid var(--foreground);
+    margin-right: 10px;
+    vertical-align: top;
+  }
+
+  input[type="file"] {
+    margin-bottom: 0.25em;
+  }
+
   h3, .answers {
     font-size: 1.17em;
     margin-left: 1.75em;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -36,7 +36,7 @@ interface Answer {
     date: string,
     answerer_name: string,
     helpfulness: number,
-    photos: {id: number, url: string}[]
+    photos: string[]
 }
 
 // `GET /qa/questions` returns an object whose `.results` property is an array of `Question`s.


### PR DESCRIPTION
![attach_images](https://user-images.githubusercontent.com/1874214/140837333-4a40c9a3-7324-482b-8695-24dc37630517.png)
![view_images](https://user-images.githubusercontent.com/1874214/140837343-43922d1e-87ce-4269-9054-2a39ae2398a5.png)

### Functionality

When adding an answer, the user may select up to five images to attach. These images display at the bottom of the form. They are converted into [blobs](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL), but only the URL is "uploaded" to the server, making them useless outside the current session.

When viewing answers, attached images are displayed as thumbnails below. If the user clicks on a thumbnail, it displays as a fullscreen modal.