### PR TITLE
Outfit Persistence and Related items bug fixes

### DIFF
--- a/src/related-items-and-comparisons/CardItem.jsx
+++ b/src/related-items-and-comparisons/CardItem.jsx
@@ -1,12 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import ComparisonModal from './ComparisonModal.jsx';
 import './related-items-and-comparisons.scss';
 import { Price, StarRating } from '../common';
 
 const CardItem = (props) => {
   const [modal, toggleModal] = useState(false);
-  var image_url = '';
-  var defaultPrice = '??';
   var salePrice = null;
 
   const compare = (e) => {
@@ -23,8 +21,6 @@ const CardItem = (props) => {
 
   for (var i = 0; i < props.styles.length; i++) {
     if (props.styles[i]['default?'] === true) {
-      image_url = props.styles[i].photos[0].url; // unused for now, need to clarify what default images should be
-      defaultPrice = props.styles[i].original_price;
       salePrice = props.styles[i].sale_price;
     }
   }

--- a/src/related-items-and-comparisons/OutfitCard.jsx
+++ b/src/related-items-and-comparisons/OutfitCard.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { Price, StarRating } from '../common';
 
 const OutfitCard = (props) => {
-  var image_url = '';
-  var defaultPrice = '??';
   var salePrice = null;
 
   const removeFromOutfit = (e) => {
@@ -13,8 +11,6 @@ const OutfitCard = (props) => {
 
   for (var i = 0; i < props.styles.length; i++) {
     if (props.styles[i]['default?'] === true) {
-      image_url = props.styles[i].photos[0].url; // unused for now, need to clarify what default images should be
-      defaultPrice = props.styles[i].original_price;
       salePrice = props.styles[i].sale_price;
     }
   }

--- a/src/related-items-and-comparisons/OutfitList.jsx
+++ b/src/related-items-and-comparisons/OutfitList.jsx
@@ -5,11 +5,11 @@ const OutfitList = (props) => {
   // hook for array of outfits, starts with nothing by default
   // items must be unique, so clicking does nothing if product is already in the list
   // should always have an "add to list" card
+  var storedFits = JSON.parse(localStorage.getItem('outfit')) || [];
   const [outfitIDs, updateOutfitIDs] = useState([]);
-  const [outfit, updateOutfit] = useState([]);
+  const [outfit, updateOutfit] = useState(storedFits);
   const [currList, setCurrList] = useState(outfit);
   const [currIndex, setCurrIndex] = useState(0);
-
 
 
   const next = () => {
@@ -28,6 +28,7 @@ const OutfitList = (props) => {
       updateOutfit([...outfit, props.currentProduct]);
       updateOutfitIDs([...outfitIDs, props.currentProduct.product.id]);
     }
+    // localStorage.setItem('outfit', JSON.stringify(outfit));
   };
 
   const removeFromOutfit = (product) => {
@@ -41,6 +42,7 @@ const OutfitList = (props) => {
       updateOutfit(prevState => outfit.splice(index, 1));
       updateOutfitIDs(prevState => outfitIDs.splice(index, 1));
     }
+    // localStorage.setItem('outfit', JSON.stringify(outfit));
   };
 
 
@@ -49,6 +51,10 @@ const OutfitList = (props) => {
 
   const leftButton = currIndex === 0 ? null :
     <button type="button" className="left-arrow" onClick={prev}> &lt; </button>;
+
+    useEffect(() => {
+      localStorage.setItem('outfit', JSON.stringify(outfit));
+    })
 
   return (
     <div>

--- a/src/related-items-and-comparisons/OutfitList.jsx
+++ b/src/related-items-and-comparisons/OutfitList.jsx
@@ -7,7 +7,7 @@ const OutfitList = (props) => {
   // should always have an "add to list" card
   // var storedFits = JSON.parse(localStorage.getItem('outfit')) || [];
   // var storedIDs = JSON.parse(localStorage.getItem('outfitIDs')) || [];
-  const [outfit, updateOutfit] = useState(JSON.parse(localStorage.getItem('outfit')) || []);
+  const [outfit, updateOutfit] = useState(() => JSON.parse(localStorage.getItem('outfit')) || []);
   const [outfitIDs, updateOutfitIDs] = useState(() => JSON.parse(localStorage.getItem('outfitIDs')) || []);
   // const [outfitIDs, updateOutfitIDs] = useState(storedIDs);
   // const [outfit, updateOutfit] = useState(storedFits);

--- a/src/related-items-and-comparisons/OutfitList.jsx
+++ b/src/related-items-and-comparisons/OutfitList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import OutfitCard from './OutfitCard.jsx';
 
 const OutfitList = (props) => {
@@ -7,8 +7,10 @@ const OutfitList = (props) => {
   // should always have an "add to list" card
   var storedFits = JSON.parse(localStorage.getItem('outfit')) || [];
   var storedIDs = JSON.parse(localStorage.getItem('outfitIDs')) || [];
-  const [outfitIDs, updateOutfitIDs] = useState(storedIDs);
-  const [outfit, updateOutfit] = useState(storedFits);
+  // const [outfitIDs, updateOutfitIDs] = useState(storedIDs);
+  // const [outfit, updateOutfit] = useState(storedFits);
+  var outfitIDs = storedIDs;
+  var outfit = storedFits;
   const [currIndex, setCurrIndex] = useState(0);
 
   // using this for a homemade forceUpdate
@@ -45,7 +47,7 @@ const OutfitList = (props) => {
     if (index > -1) {
       // updateOutfit(prevState => outfit.splice(index, 1));
       // updateOutfitIDs(prevState => outfitIDs.splice(index, 1));
-      outfit.splice(index, 1)
+      outfit.splice(index, 1);
       outfitIDs.splice(index, 1);
       setVal(val => val + 1);
     }

--- a/src/related-items-and-comparisons/OutfitList.jsx
+++ b/src/related-items-and-comparisons/OutfitList.jsx
@@ -5,16 +5,18 @@ const OutfitList = (props) => {
   // hook for array of outfits, starts with nothing by default
   // items must be unique, so clicking does nothing if product is already in the list
   // should always have an "add to list" card
-  var storedFits = JSON.parse(localStorage.getItem('outfit')) || [];
-  var storedIDs = JSON.parse(localStorage.getItem('outfitIDs')) || [];
+  // var storedFits = JSON.parse(localStorage.getItem('outfit')) || [];
+  // var storedIDs = JSON.parse(localStorage.getItem('outfitIDs')) || [];
+  const [outfit, updateOutfit] = useState(JSON.parse(localStorage.getItem('outfit')) || []);
+  const [outfitIDs, updateOutfitIDs] = useState(() => JSON.parse(localStorage.getItem('outfitIDs')) || []);
   // const [outfitIDs, updateOutfitIDs] = useState(storedIDs);
   // const [outfit, updateOutfit] = useState(storedFits);
-  var outfitIDs = storedIDs;
-  var outfit = storedFits;
+  // var outfitIDs = storedIDs;
+  // var outfit = storedFits;
   const [currIndex, setCurrIndex] = useState(0);
 
   // using this for a homemade forceUpdate
-  const [val, setVal] = useState(0);
+  // const [val, setVal] = useState(0);
 
 
   const next = () => {
@@ -27,17 +29,38 @@ const OutfitList = (props) => {
 
   const addToOutfit = () => {
     if (!outfitIDs.includes(props.currentProduct.product.id)) {
-      // updateOutfit(prevState => [...outfit, props.currentProduct]);
+      // updateOutfit([...outfit, props.currentProduct]);
       // updateOutfitIDs([...outfitIDs, props.currentProduct.product.id]);
-      outfit.push(props.currentProduct);
-      outfitIDs.push(props.currentProduct.product.id);
-      setVal(val => val + 1);
+      // outfit.push(props.currentProduct);
+      // outfitIDs.push(props.currentProduct.product.id);
+      // setVal(val => val + 1);
+      const newOutfit = [...outfit, props.currentProduct];
+      localStorage.setItem('outfit', JSON.stringify(newOutfit));
+      updateOutfit(newOutfit);
+      const newOutfitIDs = [...outfitIDs, props.currentProduct.product.id];
+      localStorage.setItem('outfitIDs', JSON.stringify(newOutfitIDs));
+      updateOutfitIDs(newOutfitIDs);
     }
-    localStorage.setItem('outfit', JSON.stringify(outfit));
-    localStorage.setItem('outfitIDs', JSON.stringify(outfitIDs));
+    // localStorage.setItem('outfit', JSON.stringify(outfit));
+    // localStorage.setItem('outfitIDs', JSON.stringify(outfitIDs));
   };
 
   const removeFromOutfit = (product) => {
+    // Could have sliced first, then spliced new array
+    var newOutfitRemoved = [];
+    var newOutfitIDsRemoved = [];
+    for (var i = 0; i < outfit.length; i++) {
+      if (outfit[i].product.id !== product.id) {
+        newOutfitRemoved.push(outfit[i]);
+        newOutfitIDsRemoved.push(outfit[i].product.id);
+      }
+    }
+    localStorage.setItem('outfit', JSON.stringify(newOutfitRemoved));
+    updateOutfit(newOutfitRemoved);
+    localStorage.setItem('outfitIDs', JSON.stringify(newOutfitIDsRemoved));
+    updateOutfitIDs(newOutfitIDsRemoved);
+
+    /*
     var index = -1;
     for (var i = 0; i < outfit.length; i++) {
       if (outfit[i].product.id === product.id) {
@@ -45,18 +68,27 @@ const OutfitList = (props) => {
       }
     }
     if (index > -1) {
+      console.log(index);
+      var newOutfitRemove = outfit.splice(index, 1);
+      console.log(newOutfitRemove);
+      localStorage.setItem('outfit', JSON.stringify(newOutfitRemove));
+      updateOutfit(newOutfitRemove);
+      const newOutfitIDs = outfitIDs.splice(index, 1);
+      localStorage.setItem('outfitIDs', JSON.stringify(newOutfitIDs));
+      updateOutfitIDs(newOutfitIDs);
       // updateOutfit(prevState => outfit.splice(index, 1));
       // updateOutfitIDs(prevState => outfitIDs.splice(index, 1));
-      outfit.splice(index, 1);
-      outfitIDs.splice(index, 1);
-      setVal(val => val + 1);
+      // outfit.splice(index, 1);
+      // outfitIDs.splice(index, 1);
+      // setVal(val => val + 1);
     }
-    localStorage.setItem('outfit', JSON.stringify(outfit));
-    localStorage.setItem('outfitIDs', JSON.stringify(outfitIDs));
+    // localStorage.setItem('outfit', JSON.stringify(outfit));
+    // localStorage.setItem('outfitIDs', JSON.stringify(outfitIDs));
+    */
   };
 
 
-  const rightButton = (currIndex === outfit.length - 1 || outfit.length === 0) ? null :
+  const rightButton = currIndex === outfit.length - 1 || outfit.length === 0 ? null :
     <button type="button" className="right-arrow" onClick={next}> &gt; </button>;
 
   const leftButton = currIndex === 0 ? null :

--- a/src/related-items-and-comparisons/OutfitList.jsx
+++ b/src/related-items-and-comparisons/OutfitList.jsx
@@ -10,6 +10,8 @@ const OutfitList = (props) => {
   const [currList, setCurrList] = useState(outfit);
   const [currIndex, setCurrIndex] = useState(0);
 
+
+
   const next = () => {
     setCurrIndex(currIndex + 1); // this is changing what currIndex will be the next time the component renders
     setCurrList(outfit.slice(currIndex + 1));

--- a/src/related-items-and-comparisons/OutfitList.jsx
+++ b/src/related-items-and-comparisons/OutfitList.jsx
@@ -6,29 +6,33 @@ const OutfitList = (props) => {
   // items must be unique, so clicking does nothing if product is already in the list
   // should always have an "add to list" card
   var storedFits = JSON.parse(localStorage.getItem('outfit')) || [];
-  const [outfitIDs, updateOutfitIDs] = useState([]);
+  var storedIDs = JSON.parse(localStorage.getItem('outfitIDs')) || [];
+  const [outfitIDs, updateOutfitIDs] = useState(storedIDs);
   const [outfit, updateOutfit] = useState(storedFits);
-  const [currList, setCurrList] = useState(outfit);
   const [currIndex, setCurrIndex] = useState(0);
+
+  // using this for a homemade forceUpdate
+  const [val, setVal] = useState(0);
 
 
   const next = () => {
     setCurrIndex(currIndex + 1); // this is changing what currIndex will be the next time the component renders
-    setCurrList(outfit.slice(currIndex + 1));
   };
 
   const prev = () => {
     setCurrIndex(currIndex - 1);
-    setCurrList(outfit.slice(currIndex - 1));
   };
 
-  const addToOutfit = () => { // need to replace with outfit from the current page
+  const addToOutfit = () => {
     if (!outfitIDs.includes(props.currentProduct.product.id)) {
-      // updateOutfit([...outfit, props.products[0].product]);
-      updateOutfit([...outfit, props.currentProduct]);
-      updateOutfitIDs([...outfitIDs, props.currentProduct.product.id]);
+      // updateOutfit(prevState => [...outfit, props.currentProduct]);
+      // updateOutfitIDs([...outfitIDs, props.currentProduct.product.id]);
+      outfit.push(props.currentProduct);
+      outfitIDs.push(props.currentProduct.product.id);
+      setVal(val => val + 1);
     }
-    // localStorage.setItem('outfit', JSON.stringify(outfit));
+    localStorage.setItem('outfit', JSON.stringify(outfit));
+    localStorage.setItem('outfitIDs', JSON.stringify(outfitIDs));
   };
 
   const removeFromOutfit = (product) => {
@@ -39,10 +43,14 @@ const OutfitList = (props) => {
       }
     }
     if (index > -1) {
-      updateOutfit(prevState => outfit.splice(index, 1));
-      updateOutfitIDs(prevState => outfitIDs.splice(index, 1));
+      // updateOutfit(prevState => outfit.splice(index, 1));
+      // updateOutfitIDs(prevState => outfitIDs.splice(index, 1));
+      outfit.splice(index, 1)
+      outfitIDs.splice(index, 1);
+      setVal(val => val + 1);
     }
-    // localStorage.setItem('outfit', JSON.stringify(outfit));
+    localStorage.setItem('outfit', JSON.stringify(outfit));
+    localStorage.setItem('outfitIDs', JSON.stringify(outfitIDs));
   };
 
 
@@ -51,10 +59,6 @@ const OutfitList = (props) => {
 
   const leftButton = currIndex === 0 ? null :
     <button type="button" className="left-arrow" onClick={prev}> &lt; </button>;
-
-    useEffect(() => {
-      localStorage.setItem('outfit', JSON.stringify(outfit));
-    })
 
   return (
     <div>
@@ -68,7 +72,7 @@ const OutfitList = (props) => {
             <div className="add-button">+</div>
             <div className="add-text">Add to Outfit</div>
           </div>
-          {outfit.map(({ product, metadata, styles }) =>
+          {outfit.slice(currIndex).map(({ product, metadata, styles }) =>
             <OutfitCard key={product.id} product={product} rating={metadata.rating} styles={styles} remove={removeFromOutfit} />
           )}
         </div>

--- a/src/related-items-and-comparisons/RelatedItemsList.jsx
+++ b/src/related-items-and-comparisons/RelatedItemsList.jsx
@@ -14,10 +14,10 @@ const RelatedItemsList = (props) => {
     setCurrIndex(currIndex - 1);
   };
 
-  const rightButton = (currIndex === props.products.length - 1 || props.products.length === 0) ? null :
+  const rightButton = currIndex === props.products.length - 1 || props.products.length === 0 ? null :
     <button type="button" className="right-arrow" onClick={next}> &gt; </button>;
 
-  const leftButton = (currIndex === 0 || props.products.length === 0) ? null :
+  const leftButton = currIndex === 0 || props.products.length === 0 ? null :
     <button type="button" className="left-arrow" onClick={prev}> &lt; </button>;
 
   return (

--- a/src/related-items-and-comparisons/RelatedItemsList.jsx
+++ b/src/related-items-and-comparisons/RelatedItemsList.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import CardItem from './CardItem.jsx';
 
 const RelatedItemsList = (props) => {
-  const products = props.products;
   const [currIndex, setCurrIndex] = useState(0);
 
   // "useEffect is componentDidMount, componentDidUpdate, and componentWillUnmount combined"
@@ -15,12 +14,11 @@ const RelatedItemsList = (props) => {
     setCurrIndex(currIndex - 1);
   };
 
-  const rightButton = currIndex === products.length - 1 ? null :
+  const rightButton = (currIndex === props.products.length - 1 || props.products.length === 0) ? null :
     <button type="button" className="right-arrow" onClick={next}> &gt; </button>;
 
-  const leftButton = currIndex === 0 ? null :
+  const leftButton = (currIndex === 0 || props.products.length === 0) ? null :
     <button type="button" className="left-arrow" onClick={prev}> &lt; </button>;
-
 
   return (
     <div>
@@ -30,7 +28,7 @@ const RelatedItemsList = (props) => {
           {leftButton}
         </div>
         <div className="card-list">
-          {products.slice(currIndex).map(({ product, metadata, styles }) =>
+          {props.products.slice(currIndex).map(({ product, metadata, styles }) =>
             <CardItem key={product.id} product={product} rating={metadata.rating} styles={styles} currentProduct={props.currentProduct}/>
           )}
         </div>

--- a/src/related-items-and-comparisons/RelatedItemsList.jsx
+++ b/src/related-items-and-comparisons/RelatedItemsList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import CardItem from './CardItem.jsx';
 
 const RelatedItemsList = (props) => {

--- a/src/related-items-and-comparisons/index.jsx
+++ b/src/related-items-and-comparisons/index.jsx
@@ -9,7 +9,7 @@ const RelatedItemsAndComparisons = (props) => (
   <div id="related-items-and-comparisons">
     <div>
       <RelatedItemsList products={props.products} currentProduct={props.info}/>
-      <OutfitList products={props.products} currentProduct={props.info}/>
+      <OutfitList currentProduct={props.info}/>
     </div>
   </div>
 );

--- a/src/related-items-and-comparisons/index.jsx
+++ b/src/related-items-and-comparisons/index.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import CardItem from './CardItem.jsx';
 import RelatedItemsList from './RelatedItemsList.jsx';
-import ComparisonModal from './ComparisonModal.jsx';
 import OutfitList from './OutfitList.jsx';
 import './related-items-and-comparisons.scss';
 

--- a/src/related-items-and-comparisons/index.jsx
+++ b/src/related-items-and-comparisons/index.jsx
@@ -5,13 +5,11 @@ import ComparisonModal from './ComparisonModal.jsx';
 import OutfitList from './OutfitList.jsx';
 import './related-items-and-comparisons.scss';
 
-import { products } from './sampleData.js';
-
 const RelatedItemsAndComparisons = (props) => (
   <div id="related-items-and-comparisons">
     <div>
-      <RelatedItemsList products={products} currentProduct={props.info}/>
-      <OutfitList products={products} currentProduct={props.info}/>
+      <RelatedItemsList products={props.products} currentProduct={props.info}/>
+      <OutfitList products={props.products} currentProduct={props.info}/>
     </div>
   </div>
 );

--- a/src/related-items-and-comparisons/related-items-and-comparisons.scss
+++ b/src/related-items-and-comparisons/related-items-and-comparisons.scss
@@ -69,14 +69,14 @@
     position: relative;
     height: 50px;
     left: 0px;
-    z-index: 100;
+    z-index: 99;
   }
 
   .right-arrow {
     position: relative;
     height: 50px;
     right: 0px;
-    z-index: 100;
+    z-index: 99;
   }
 
   .comparison-modal {


### PR DESCRIPTION
http://g.recordit.co/r7T2nekdw9.gif

(gif was 12.7mb and github only allows up to 10, I can do a shorter gif if thats better)

### Components Changed

- OutfitList
    - Using local storage to allow user Outfit to persist through page changes/leaving the page
    - removed sample data prop
- RelatedItemsList
    - Bug Fix: scroll buttons appeared when there were no related items given, now component will be empty aside from "Related Products" title
- index
    - removed sampleData import 
    - removed sampleData prop for OutfitList
- CSS
    - Adjusted CSS for scroll buttons so comparison modal appears in front of them on the z-index

 